### PR TITLE
Only enable ConsoleSpanExporter for DEBUG level

### DIFF
--- a/src/opentelemetry/launcher/configuration.py
+++ b/src/opentelemetry/launcher/configuration.py
@@ -345,7 +345,7 @@ def configure_opentelemetry(
 
     get_tracer_provider().resource = Resource(resource_attributes)
 
-    if log_level >= DEBUG:
+    if log_level <= DEBUG:
         get_tracer_provider().add_span_processor(
             BatchExportSpanProcessor(ConsoleSpanExporter())
         )


### PR DESCRIPTION
Currently, the tracer is configured to dumps all span data into stdout for `DEBUG` and above, which is effectively all log levels. This is super noisy and makes application logs unusable. 

I *think* the intention was to only enable ConsoleSpanExporter on `DEBUG` and `NOTSET` level?