### PR TITLE
add telemetry.distro attributes

### DIFF
--- a/src/opentelemetry/launcher/configuration.py
+++ b/src/opentelemetry/launcher/configuration.py
@@ -42,6 +42,8 @@ from opentelemetry.sdk.trace.export import (
 )
 from opentelemetry.trace import get_tracer_provider, set_tracer_provider
 
+from .version import __version__
+
 _env = Env()
 _logger = getLogger(__name__)
 
@@ -337,6 +339,9 @@ def configure_opentelemetry(
                     service_version,
                 )
             resource_attributes["service.version"] = service_version
+
+        resource_attributes["telemetry.distro.name"] = "lightstep"
+        resource_attributes["telemetry.distro.version"] = __version__
 
         resource_attributes_copy = resource.attributes.copy()
         resource_attributes_copy.update(resource_attributes)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -26,6 +26,7 @@ from opentelemetry.launcher.configuration import (
     InvalidConfigurationError,
     _ATTRIBUTE_HOST_NAME,
 )
+from opentelemetry.launcher.version import __version__ as launcher_version
 from opentelemetry.sdk.version import __version__
 from opentelemetry import baggage, trace
 from opentelemetry.propagate import get_global_textmap
@@ -191,6 +192,8 @@ class TestConfiguration(TestCase):
                     "service.name": "service_name",
                     "service.version": "service_version",
                     _ATTRIBUTE_HOST_NAME: "the_hostname",
+                    "telemetry.distro.name": "lightstep",
+                    "telemetry.distro.version": launcher_version,
                 }
             )
         )
@@ -216,6 +219,8 @@ class TestConfiguration(TestCase):
                     "telemetry.sdk.name": "opentelemetry",
                     "service.name": "service_name",
                     _ATTRIBUTE_HOST_NAME: "the_hostname",
+                    "telemetry.distro.name": "lightstep",
+                    "telemetry.distro.version": launcher_version,
                 }
             )
         )
@@ -323,7 +328,9 @@ class TestConfiguration(TestCase):
                     "telemetry.sdk.version": __version__,
                     "service.name": "service_name",
                     _ATTRIBUTE_HOST_NAME: "the_hostname",
-                    "telemetry.sdk.name": "opentelemetry"
+                    "telemetry.sdk.name": "opentelemetry",
+                    "telemetry.distro.name": "lightstep",
+                    "telemetry.distro.version": launcher_version,
                 }
             )
         )
@@ -351,7 +358,9 @@ class TestConfiguration(TestCase):
                     "telemetry.sdk.version": __version__,
                     "service.name": "service_name",
                     _ATTRIBUTE_HOST_NAME: "other_hostname",
-                    "telemetry.sdk.name": "opentelemetry"
+                    "telemetry.sdk.name": "opentelemetry",
+                    "telemetry.distro.name": "lightstep",
+                    "telemetry.distro.version": launcher_version,
                 }
             )
         )


### PR DESCRIPTION
This will allow us to differentiate between users of the launcher vs standard otel.