### PR TITLE
update opentelemetry-instrumentation to 0.38b0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 1.14.0
+
+- Updated opentelemetry-instrumentation to 0.38b0
+
 ## 1.13.0
 
 - Updated setuptools to 65.5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     opentelemetry-sdk == 1.16.0
     opentelemetry-exporter-otlp == 1.16.0
     opentelemetry-propagator-b3 == 1.16.0
-    opentelemetry-instrumentation == 0.37b0
+    opentelemetry-instrumentation == 0.38b0
 
 [options.extras_require]
 test =

--- a/src/opentelemetry/launcher/version.py
+++ b/src/opentelemetry/launcher/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.13.0"
+__version__ = "1.14.0"


### PR DESCRIPTION
https://github.com/lightstep/otel-launcher-python/issues/146

This updates opentelemetry-instrumentation to 0.38b0 which was released March 22, 2023